### PR TITLE
Add browserify to get the server started

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "binary-pack": "0.0.3",
+    "browserify": "^10.2.4",
     "compression": "^1.0.3",
     "debug": "^2.1.3",
     "duplex": "^1.0.0",


### PR DESCRIPTION
When I tried to start the server with `node server/server.js` it failed with the following message which is fixed by this PR:

```
Error: Cannot find module 'browserify'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/beeman/git/loopback-example-pubsub/server/boot/pubsub-client.js:2:18)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
/Users/beeman/git/loopback-example-pubsub/node_modules/loopback-boot/lib/executor.js:271
      throw err;
            ^
Error: Cannot find module 'browserify'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/beeman/git/loopback-example-pubsub/server/boot/pubsub-client.js:2:18)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```